### PR TITLE
Add static tests with JET

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1'
-          - 'nightly'
+          - '1.8'
+          - '~1.9.0-0'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1.8'
+          - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 [compat]
 ChainRulesCore = "1"
 FrankWolfe = "0.2.1"
-JET = "0.7.11"
 Krylov = "0.8, 0.9"
 LinearOperators = "2.3"
 SimpleTraits = "0.9"
@@ -39,6 +38,7 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
@@ -48,4 +48,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "JET", "JuliaFormatter", "LinearAlgebra", "Literate", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "UnicodePlots", "Zygote"]
+test = ["Aqua", "Documenter", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "JET", "JuliaFormatter", "LinearAlgebra", "Literate", "Pkg", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "UnicodePlots", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 [compat]
 ChainRulesCore = "1"
 FrankWolfe = "0.2.1"
+JET = "0.7.11"
 Krylov = "0.8, 0.9"
 LinearOperators = "2.3"
 SimpleTraits = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
@@ -46,4 +47,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "Documenter", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "JuliaFormatter", "LinearAlgebra", "Literate", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "UnicodePlots", "Zygote"]
+test = ["Aqua", "Documenter", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "JET", "JuliaFormatter", "LinearAlgebra", "Literate", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "UnicodePlots", "Zygote"]

--- a/src/imitation_loss/imitation_loss.jl
+++ b/src/imitation_loss/imitation_loss.jl
@@ -44,7 +44,7 @@ end
 Retrieve `y_true` from `t_true`.
 This method should be implemented when using a custom data structure for `t_true` other than a `NamedTuple`.
 """
-get_y_true(t_true) = error("not implemented")
+function get_y_true end
 
 """
     get_y_true(t_true::NamedTuple)

--- a/src/ssvm/isbaseloss.jl
+++ b/src/ssvm/isbaseloss.jl
@@ -17,6 +17,4 @@ For `δ::L` to comply with this interface, the following methods must exist:
 
 Compute `argmax_y {δ(y, y_true) + α θᵀ(y - y_true)}` to deduce the gradient of a `StructuredSVMLoss`.
 """
-@traitfn function compute_maximizer(δ::L, θ, α, y_true; kwargs...) where {L; IsBaseLoss{L}}
-    return error("not implemented")
-end
+function compute_maximizer end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,12 +12,6 @@ includet("utils/error.jl")
 includet("utils/perf.jl")
 includet("utils/pipeline.jl")
 
-function get_pkg_version(name::AbstractString)
-    deps = Pkg.dependencies()
-    p = only(x for x in values(deps) if x.name == name)
-    return p.version
-end
-
 @testset verbose = true "InferOpt.jl" begin
     @testset verbose = true "Code quality (Aqua.jl)" begin
         Aqua.test_all(InferOpt; ambiguities=false)
@@ -26,10 +20,8 @@ end
         @test format(InferOpt; verbose=false, overwrite=false)
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
-        if get_pkg_version("JET") >= v"0.7.11"
-            JET.test_package("InferOpt"; toplevel_logger=nothing)
-        else
-            @test string(JET.report_package(InferOpt)) == "No errors detected\n"
+        if VERSION >= v"1.8"
+            JET.test_package(InferOpt; toplevel_logger=nothing)
         end
     end
     @testset verbose = true "Jacobian approx" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Aqua
 using InferOpt
 using JET
 using JuliaFormatter
+using Pkg
 using Test
 using Zygote
 
@@ -10,6 +11,12 @@ includet("utils/dataset.jl")
 includet("utils/error.jl")
 includet("utils/perf.jl")
 includet("utils/pipeline.jl")
+
+function get_pkg_version(name::AbstractString)
+    deps = Pkg.dependencies()
+    p = only(x for x in values(deps) if x.name == name)
+    return p.version
+end
 
 @testset verbose = true "InferOpt.jl" begin
     @testset verbose = true "Code quality (Aqua.jl)" begin
@@ -19,7 +26,11 @@ includet("utils/pipeline.jl")
         @test format(InferOpt; verbose=false, overwrite=false)
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
-        JET.test_package("InferOpt"; toplevel_logger=nothing)
+        if get_pkg_version("JET") >= v"0.7.11"
+            JET.test_package("InferOpt"; toplevel_logger=nothing)
+        else
+            @test string(JET.report_package(InferOpt)) == "No errors detected\n"
+        end
     end
     @testset verbose = true "Jacobian approx" begin
         include("jacobian_approx.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ includet("utils/pipeline.jl")
         @test format(InferOpt; verbose=false, overwrite=false)
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
-        JET.test_package("InferOpt"; verbose=false, overwrite=false)
+        JET.test_package("InferOpt"; toplevel_logger=nothing)
     end
     @testset verbose = true "Jacobian approx" begin
         include("jacobian_approx.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ includet("utils/pipeline.jl")
     end
     @testset verbose = true "Code correctness (JET.jl)" begin
         if VERSION >= v"1.8"
-            JET.test_package(InferOpt; toplevel_logger=nothing)
+            JET.test_package(InferOpt; toplevel_logger=nothing, mode=:typo)
         end
     end
     @testset verbose = true "Jacobian approx" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using Revise
 using Aqua
 using InferOpt
+using JET
 using JuliaFormatter
 using Test
+using Zygote
 
 includet("utils/dataset.jl")
 includet("utils/error.jl")
@@ -15,6 +17,9 @@ includet("utils/pipeline.jl")
     end
     @testset verbose = true "Code formatting (JuliaFormatter.jl)" begin
         @test format(InferOpt; verbose=false, overwrite=false)
+    end
+    @testset verbose = true "Code correctness (JET.jl)" begin
+        JET.test_package("InferOpt"; verbose=false, overwrite=false)
     end
     @testset verbose = true "Jacobian approx" begin
         include("jacobian_approx.jl")


### PR DESCRIPTION
[JET.jl](https://github.com/aviatesk/JET.jl) enables static testing of code correctness, it's good to catch typos among other things. We could also use it to test for dynamic dispatch (although I'm sure the Frank-Wolfe part is ripe with it)

I had to remove the generic methods throwing errors, and replace them with empty functions. It's better style anyway.
However, this leads JET to assume that no method exists for `compute_maximizer(base_loss, θ, α, y_true)` in the SSVM. As a result, I [switched the analysis](https://aviatesk.github.io/JET.jl/dev/jetanalysis/#jetanalysis-config) to `:typo` mode for now instead of the more complete version. I opened an issue to keep track of this: https://github.com/aviatesk/JET.jl/issues/495

Tests might fail on Julia 1.10 because of a bug in Zygote: https://github.com/FluxML/Zygote.jl/issues/1410