### PR TITLE
Fix bug in PerturbedMultiplicative

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {Guillaume Dalle, Léo Baty, Louis Bouvier and Axel Parmentier},
 	title   = {InferOpt.jl},
 	url     = {https://github.com/axelparmentier/InferOpt.jl},
-	version = {v0.7.0},
+	version = {v0.7.1},
 	year    = {2025},
-	month   = {4}
+	month   = {7}
 }

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InferOpt"
 uuid = "4846b161-c94e-4150-8dac-c7ae193c601f"
 authors = ["Guillaume Dalle", "Léo Baty", "Louis Bouvier", "Axel Parmentier"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/InferOpt.jl
+++ b/src/InferOpt.jl
@@ -15,6 +15,8 @@ using DifferentiableExpectations:
 using Distributions:
     Distributions,
     ContinuousUnivariateDistribution,
+    AffineDistribution,
+    Dirac,
     LogNormal,
     Normal,
     product_distribution,

--- a/src/layers/perturbed/utils.jl
+++ b/src/layers/perturbed/utils.jl
@@ -26,3 +26,7 @@ It is equal to ``logpdf(d, log(x)) - log(x)``.
 function Distributions.logpdf(d::ExponentialOf, x::Real)
     return logpdf(d.dist, log(x)) - log(x)
 end
+
+function Base.:*(x::Real, d::ExponentialOf)
+    return iszero(x) ? Dirac(0.0) : AffineDistribution(zero(x), x, d)
+end

--- a/test/perturbed.jl
+++ b/test/perturbed.jl
@@ -112,3 +112,11 @@ end
     @test Ja ≈ Jz rtol = 0.01
     @test Jm ≈ Jz rtol = 0.01
 end
+
+@testitem "Perturbed - Misc" begin
+    # Make sure that having 0s in θ works
+    perturbed = PerturbedMultiplicative(identity; ε=1.0, nb_samples=1e4, seed=0)
+    θ = [1.0, 0.0]
+    y = perturbed(θ)
+    @test iszero(y[2])
+end


### PR DESCRIPTION
See #124.

The current workaround is to overwrite Base.* and check if the input is equal to 0.