### PR TITLE
Issue-129

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,6 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
@@ -72,4 +71,4 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "DifferentiableFrankWolfe", "Distributions", "Documenter", "FiniteDifferences", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "HiGHS", "ImplicitDifferentiation", "JET", "JuliaFormatter", "JuMP", "LinearAlgebra", "Literate", "Pkg", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "TestItemRunner", "UnicodePlots", "Zygote"]
+test = ["Aqua", "DifferentiableFrankWolfe", "Distributions", "Documenter", "FiniteDifferences", "Flux", "FrankWolfe", "Graphs", "HiGHS", "ImplicitDifferentiation", "JET", "JuliaFormatter", "JuMP", "LinearAlgebra", "Literate", "Pkg", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "TestItemRunner", "UnicodePlots", "Zygote"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -17,4 +17,3 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 Documenter = "1.3"
-GridGraphs = "0.10"

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -34,20 +34,49 @@ Random.seed!(63);
 For the purposes of this tutorial, we consider grid graphs, as implemented in [GridGraphs.jl](https://github.com/gdalle/GridGraphs.jl).
 In such graphs, each vertex corresponds to a couple of coordinates $(i, j)$, where $1 \leq i \leq h$ and $1 \leq j \leq w$.
 
-To ensure acyclicity, we only allow the user to move right, down or both.
+To ensure acyclicity, we only allow the user to move right or down.
 Since the cost of a move is defined as the cost of the arrival vertex, any grid graph is entirely characterized by its cost matrix $\theta \in \mathbb{R}^{h \times w}$.
 =#
 
 h, w = 50, 100
-queen_directions = GridGraphs.QUEEN_DIRECTIONS_ACYCLIC
-g = GridGraph(rand(h, w); directions=queen_directions);
+g = GridGraph(rand(h, w));
 
 #=
-For convenience, GridGraphs.jl also provides custom functions to compute shortest paths efficiently.
-Let us see what those paths look like.
+We compute shortest paths from the top-left to the bottom-right corner using dynamic programming,
+only allowing moves right (east) or down (south) to ensure acyclicity.
 =#
 
-p = path_to_matrix(g, grid_topological_sort(g, 1, nv(g)));
+function grid_shortest_path_matrix(g::GridGraph)
+    h, w = height(g), width(g)
+    n = nv(g)
+    dist = fill(Inf, n)
+    prev = zeros(Int, n)
+    dist[1] = vertex_weight(g, 1)
+    for v in 1:(n - 1)
+        isinf(dist[v]) && continue
+        iv, jv = index_to_coord(g, v)
+        for (ni, nj) in ((iv + 1, jv), (iv, jv + 1))
+            if 1 <= ni <= h && 1 <= nj <= w
+                u = coord_to_index(g, ni, nj)
+                d = dist[v] + vertex_weight(g, u)
+                if d < dist[u]
+                    dist[u] = d
+                    prev[u] = v
+                end
+            end
+        end
+    end
+    mat = zeros(h, w)
+    v = n
+    while v != 0
+        i, j = index_to_coord(g, v)
+        mat[i, j] = 1.0
+        v = prev[v]
+    end
+    return mat
+end
+
+p = grid_shortest_path_matrix(g);
 spy(p)
 
 # ## Dataset
@@ -63,13 +92,11 @@ true_encoder = Chain(Dense(nb_features, 1), z -> dropdims(z; dims=1));
 #=
 The true vertex costs computed from this encoding are then used within shortest path computations.
 To be consistent with the literature, we frame this problem as a linear maximization problem, which justifies the change of sign in front of $\theta$.
-Note that `linear_maximizer` can take keyword arguments, eg. to give additional information about the instance that `θ` doesn't contain.
 =#
 
-function linear_maximizer(θ; directions)
-    g = GridGraph(-θ; directions=directions)
-    path = grid_topological_sort(g, 1, nv(g))
-    return path_to_matrix(g, path)
+function linear_maximizer(θ; kwargs...)
+    g = GridGraph(-θ)
+    return grid_shortest_path_matrix(g)
 end;
 
 #=
@@ -80,7 +107,7 @@ nb_instances = 30
 
 X_train = [randn(Float32, nb_features, h, w) for n in 1:nb_instances];
 θ_train = [true_encoder(x) for x in X_train];
-Y_train = [linear_maximizer(θ; directions=queen_directions) for θ in θ_train];
+Y_train = [linear_maximizer(θ) for θ in θ_train];
 
 # ## Learning
 
@@ -103,7 +130,7 @@ loss = FenchelYoungLoss(layer);
 This probabilistic layer is just a thin wrapper around our `linear_maximizer`, but with a very different behavior:
 =#
 
-p_layer = layer(θ_train[1]; directions=queen_directions);
+p_layer = layer(θ_train[1]);
 spy(p_layer)
 
 #=
@@ -119,7 +146,7 @@ for epoch in 1:100
     l = 0.0
     for (x, y) in zip(X_train, Y_train)
         grads = Flux.gradient(encoder) do m
-            l += loss(m(x), y; directions=queen_directions)
+            l += loss(m(x), y)
         end
         Flux.update!(opt_state, encoder, grads[1])
     end
@@ -152,7 +179,7 @@ normalized_hamming(x, y) = mean(x[i] != y[i] for i in eachindex(x));
 
 #-
 
-Y_train_pred = [linear_maximizer(encoder(x); directions=queen_directions) for x in X_train];
+Y_train_pred = [linear_maximizer(encoder(x)) for x in X_train];
 
 train_error = mean(
     normalized_hamming(y, y_pred) for (y, y_pred) in zip(Y_train, Y_train_pred)
@@ -161,7 +188,7 @@ train_error = mean(
 # Not too bad, at least compared with our random initial encoder.
 
 Y_train_pred_initial = [
-    linear_maximizer(initial_encoder(x); directions=queen_directions) for x in X_train
+    linear_maximizer(initial_encoder(x)) for x in X_train
 ];
 
 train_error_initial = mean(

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -16,8 +16,6 @@ We will use InferOpt.jl to learn the appropriate weights, so that we may propose
 =#
 
 using Flux
-using Graphs
-using GridGraphs
 using InferOpt
 using LinearAlgebra
 using ProgressMeter
@@ -31,52 +29,50 @@ Random.seed!(63);
 # ## Grid graphs
 
 #=
-For the purposes of this tutorial, we consider grid graphs, as implemented in [GridGraphs.jl](https://github.com/gdalle/GridGraphs.jl).
+For the purposes of this tutorial, we consider grid graphs.
 In such graphs, each vertex corresponds to a couple of coordinates $(i, j)$, where $1 \leq i \leq h$ and $1 \leq j \leq w$.
 
 To ensure acyclicity, we only allow the user to move right or down.
-Since the cost of a move is defined as the cost of the arrival vertex, any grid graph is entirely characterized by its cost matrix $\theta \in \mathbb{R}^{h \times w}$.
+Since the cost of a move is defined as the cost of the arrival vertex, any grid graph is entirely characterized by its weight matrix $\theta \in \mathbb{R}^{h \times w}$.
 =#
 
 h, w = 50, 100
-g = GridGraph(rand(h, w));
+θ_example = rand(h, w);
 
 #=
-Compute shortest paths from the top-left to the bottom-right corner using DP,
-only allowing moves right or down.
+Compute the path from the top-left to the bottom-right corner maximizing the sum of $\theta$ values,
+only allowing moves right or down, using dynamic programming.
 =#
 
-function grid_shortest_path_matrix(g::GridGraph)
-    h, w = height(g), width(g)
-    n = nv(g)
-    dist = fill(Inf, n)
-    prev = zeros(Int, n)
-    dist[1] = vertex_weight(g, 1)
-    for v in 1:(n - 1)
-        isinf(dist[v]) && continue
-        iv, jv = index_to_coord(g, v)
-        for (ni, nj) in ((iv + 1, jv), (iv, jv + 1))
-            if 1 <= ni <= h && 1 <= nj <= w
-                u = coord_to_index(g, ni, nj)
-                d = dist[v] + vertex_weight(g, u)
-                if d < dist[u]
-                    dist[u] = d
-                    prev[u] = v
+function grid_shortest_path_matrix(θ::AbstractMatrix)
+    h, w = size(θ)
+    dist = fill(Inf, h, w)
+    prev_i = zeros(Int, h, w)
+    prev_j = zeros(Int, h, w)
+    dist[1, 1] = -θ[1, 1]
+    for j in 1:w, i in 1:h
+        (i == 1 && j == 1) && continue
+        for (ni, nj) in ((i - 1, j), (i, j - 1))
+            if 1 <= ni && 1 <= nj
+                d = dist[ni, nj] - θ[i, j]
+                if d < dist[i, j]
+                    dist[i, j] = d
+                    prev_i[i, j] = ni
+                    prev_j[i, j] = nj
                 end
             end
         end
     end
     mat = zeros(h, w)
-    v = n
-    while v != 0
-        i, j = index_to_coord(g, v)
-        mat[i, j] = 1.0
-        v = prev[v]
+    ci, cj = h, w
+    while (ci, cj) != (0, 0)
+        mat[ci, cj] = 1.0
+        ci, cj = prev_i[ci, cj], prev_j[ci, cj]
     end
     return mat
 end
 
-p = grid_shortest_path_matrix(g);
+p = grid_shortest_path_matrix(θ_example);
 spy(p)
 
 # ## Dataset
@@ -91,12 +87,11 @@ true_encoder = Chain(Dense(nb_features, 1), z -> dropdims(z; dims=1));
 
 #=
 The true vertex costs computed from this encoding are then used within shortest path computations.
-To be consistent with the literature, we frame this problem as a linear maximization problem, which justifies the change of sign in front of $\theta$.
+To be consistent with the literature, we frame this problem as a linear maximization problem: the maximizer finds the path with maximum total weight.
 =#
 
 function linear_maximizer(θ; kwargs...)
-    g = GridGraph(-θ)
-    return grid_shortest_path_matrix(g)
+    return grid_shortest_path_matrix(θ)
 end;
 
 #=

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -42,8 +42,8 @@ h, w = 50, 100
 g = GridGraph(rand(h, w));
 
 #=
-We compute shortest paths from the top-left to the bottom-right corner using dynamic programming,
-only allowing moves right (east) or down (south) to ensure acyclicity.
+Compute shortest paths from the top-left to the bottom-right corner using DP,
+only allowing moves right or down.
 =#
 
 function grid_shortest_path_matrix(g::GridGraph)

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -40,8 +40,8 @@ h, w = 50, 100
 θ_example = rand(h, w);
 
 #=
-Compute the path from the top-left to the bottom-right corner maximizing the sum of $\theta$ values,
-only allowing moves right or down, using dynamic programming.
+With moves restricted to right or down, the shortest path from the top-left to the bottom-right
+corner can be computed using dynamic programming.
 =#
 
 function grid_shortest_path_matrix(θ::AbstractMatrix)
@@ -49,12 +49,12 @@ function grid_shortest_path_matrix(θ::AbstractMatrix)
     dist = fill(Inf, h, w)
     prev_i = zeros(Int, h, w)
     prev_j = zeros(Int, h, w)
-    dist[1, 1] = -θ[1, 1]
+    dist[1, 1] = θ[1, 1]
     for j in 1:w, i in 1:h
         (i == 1 && j == 1) && continue
         for (ni, nj) in ((i - 1, j), (i, j - 1))
             if 1 <= ni && 1 <= nj
-                d = dist[ni, nj] - θ[i, j]
+                d = dist[ni, nj] + θ[i, j]
                 if d < dist[i, j]
                     dist[i, j] = d
                     prev_i[i, j] = ni
@@ -87,11 +87,12 @@ true_encoder = Chain(Dense(nb_features, 1), z -> dropdims(z; dims=1));
 
 #=
 The true vertex costs computed from this encoding are then used within shortest path computations.
-To be consistent with the literature, we frame this problem as a linear maximization problem: the maximizer finds the path with maximum total weight.
+To be consistent with the literature, we frame this problem as a linear maximization problem, 
+which justifies the change of sign in front of $\theta$.
 =#
 
 function linear_maximizer(θ; kwargs...)
-    return grid_shortest_path_matrix(θ)
+    return grid_shortest_path_matrix(-θ)
 end;
 
 #=

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -187,9 +187,7 @@ train_error = mean(
 
 # Not too bad, at least compared with our random initial encoder.
 
-Y_train_pred_initial = [
-    linear_maximizer(initial_encoder(x)) for x in X_train
-];
+Y_train_pred_initial = [linear_maximizer(initial_encoder(x)) for x in X_train];
 
 train_error_initial = mean(
     normalized_hamming(y, y_pred) for (y, y_pred) in zip(Y_train, Y_train_pred_initial)

--- a/test/InferOptTestUtils/src/InferOptTestUtils.jl
+++ b/test/InferOptTestUtils/src/InferOptTestUtils.jl
@@ -2,8 +2,6 @@ module InferOptTestUtils
 
 using Flux
 using Flux.Losses: mse
-using Graphs
-using GridGraphs
 using LinearAlgebra
 using Statistics
 using Test

--- a/test/InferOptTestUtils/src/maximizers.jl
+++ b/test/InferOptTestUtils/src/maximizers.jl
@@ -1,30 +1,27 @@
 function shortest_path_maximizer(θ::AbstractMatrix; kwargs...)
-    g = GridGraph(-θ)
-    h, w = height(g), width(g)
-    n = nv(g)
-    dist = fill(Inf, n)
-    prev = zeros(Int, n)
-    dist[1] = vertex_weight(g, 1)
-    for v in 1:(n - 1)
-        isinf(dist[v]) && continue
-        iv, jv = index_to_coord(g, v)
-        for (ni, nj) in ((iv + 1, jv), (iv, jv + 1))
-            if 1 <= ni <= h && 1 <= nj <= w
-                u = coord_to_index(g, ni, nj)
-                d = dist[v] + vertex_weight(g, u)
-                if d < dist[u]
-                    dist[u] = d
-                    prev[u] = v
+    h, w = size(θ)
+    dist = fill(Inf, h, w)
+    prev_i = zeros(Int, h, w)
+    prev_j = zeros(Int, h, w)
+    dist[1, 1] = -θ[1, 1]
+    for j in 1:w, i in 1:h
+        (i == 1 && j == 1) && continue
+        for (ni, nj) in ((i - 1, j), (i, j - 1))
+            if 1 <= ni && 1 <= nj
+                d = dist[ni, nj] - θ[i, j]
+                if d < dist[i, j]
+                    dist[i, j] = d
+                    prev_i[i, j] = ni
+                    prev_j[i, j] = nj
                 end
             end
         end
     end
     mat = zeros(h, w)
-    v = n
-    while v != 0
-        i, j = index_to_coord(g, v)
-        mat[i, j] = 1.0
-        v = prev[v]
+    ci, cj = h, w
+    while (ci, cj) != (0, 0)
+        mat[ci, cj] = 1.0
+        ci, cj = prev_i[ci, cj], prev_j[ci, cj]
     end
     return mat
 end

--- a/test/InferOptTestUtils/src/maximizers.jl
+++ b/test/InferOptTestUtils/src/maximizers.jl
@@ -1,8 +1,32 @@
 function shortest_path_maximizer(θ::AbstractMatrix; kwargs...)
-    g = GridGraph(-θ; directions=GridGraphs.QUEEN_DIRECTIONS_ACYCLIC)
-    path = grid_topological_sort(g, 1, nv(g))
-    y = path_to_matrix(g, path)
-    return y
+    g = GridGraph(-θ)
+    h, w = height(g), width(g)
+    n = nv(g)
+    dist = fill(Inf, n)
+    prev = zeros(Int, n)
+    dist[1] = vertex_weight(g, 1)
+    for v in 1:(n - 1)
+        isinf(dist[v]) && continue
+        iv, jv = index_to_coord(g, v)
+        for (ni, nj) in ((iv + 1, jv), (iv, jv + 1))
+            if 1 <= ni <= h && 1 <= nj <= w
+                u = coord_to_index(g, ni, nj)
+                d = dist[v] + vertex_weight(g, u)
+                if d < dist[u]
+                    dist[u] = d
+                    prev[u] = v
+                end
+            end
+        end
+    end
+    mat = zeros(h, w)
+    v = n
+    while v != 0
+        i, j = index_to_coord(g, v)
+        mat[i, j] = 1.0
+        v = prev[v]
+    end
+    return mat
 end
 
 function max_pricing(θ::AbstractVector; instance::AbstractMatrix)


### PR DESCRIPTION
@BatyLeo 
So, looking at: 
 - https://github.com/gdalle/GridGraphs.jl/issues/18
 - https://github.com/gdalle/GridGraphs.jl/pull/19
 - https://github.com/gdalle/GridGraphs.jl/pull/19/changes#diff-8b082ccb7b11d5f64c760849c963d437d4f025d610a138a536900b184f4aff4c

If I understood it correctly, `GridGraphs.jl` has stripped much of its API,  in particular removed the `shortest_path.jl`, which was necessary for `shortest_path_maximizer`. So now it has be written from scratch.  

New: 
<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/d1ecb514-f34c-4cf2-9f17-5a3636394b37" />

Before: 
<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/bb1c8613-74a8-4606-be3c-6b20f3ccc006" />

I *think* this makes sense? Since `GridGraphs.jl v0.11` doesn't allow diagonals anymore, we get something more like stairs? 

Closes #129 
