### PR TITLE
Fix failing JET tests with Julia 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,10 @@
 name = "InferOpt"
 uuid = "4846b161-c94e-4150-8dac-c7ae193c601f"
-authors = ["Guillaume Dalle", "Léo Baty", "Louis Bouvier", "Axel Parmentier"]
 version = "0.7.1"
+authors = ["Guillaume Dalle", "Léo Baty", "Louis Bouvier", "Axel Parmentier"]
+
+[workspace]
+projects = ["docs", "test"]
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -14,7 +17,6 @@ FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
 ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-RequiredInterfaces = "97f35ef4-7bc5-4ec1-a41a-dcc69c7308c6"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
@@ -38,38 +40,7 @@ FrankWolfe = "0.3,0.4"
 ImplicitDifferentiation = "0.7.2"
 LinearAlgebra = "1"
 Random = "1"
-RequiredInterfaces = "0.1.3"
 Statistics = "1"
 StatsBase = "0.33, 0.34"
 StatsFuns = "1.3"
 julia = "1.10"
-
-[extras]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-DifferentiableFrankWolfe = "b383313e-5450-4164-a800-befbd27b574d"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
-FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
-HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
-UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
-
-[targets]
-test = ["Aqua", "DifferentiableFrankWolfe", "Distributions", "Documenter", "FiniteDifferences", "Flux", "FrankWolfe", "Graphs", "GridGraphs", "HiGHS", "ImplicitDifferentiation", "JET", "JuliaFormatter", "JuMP", "LinearAlgebra", "Literate", "Pkg", "ProgressMeter", "Random", "Revise", "Statistics", "Test", "TestItemRunner", "UnicodePlots", "Zygote"]

--- a/src/InferOpt.jl
+++ b/src/InferOpt.jl
@@ -27,7 +27,6 @@ using Random: Random, AbstractRNG, GLOBAL_RNG, MersenneTwister, rand, seed!
 using Statistics: mean
 using StatsBase: StatsBase, sample
 using StatsFuns: logaddexp, softmax
-using RequiredInterfaces
 
 include("interface.jl")
 

--- a/src/layers/regularized/abstract_regularized.jl
+++ b/src/layers/regularized/abstract_regularized.jl
@@ -26,8 +26,3 @@ abstract type AbstractRegularized <: AbstractOptimizationLayer end
 Return the convex penalty `Ω(y)` associated with an `AbstractRegularized` layer.
 """
 function compute_regularization end
-
-@required AbstractRegularized begin
-    # (regularized::AbstractRegularized)(θ::AbstractArray; kwargs...) # waiting for RequiredInterfaces to support this (see https://github.com/Seelengrab/RequiredInterfaces.jl/issues/11)
-    compute_regularization(::AbstractRegularized, y)
-end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,32 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DifferentiableFrankWolfe = "b383313e-5450-4164-a800-befbd27b574d"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
+InferOpt = "4846b161-c94e-4150-8dac-c7ae193c601f"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+InferOpt = {path = ".."}
+
+[compat]
+JuliaFormatter = "1"
+Test = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -28,5 +28,6 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 InferOpt = {path = ".."}
 
 [compat]
+GridGraphs = "0.10"
 JuliaFormatter = "1"
 Test = "1"

--- a/test/abstract_regularized_interface.jl
+++ b/test/abstract_regularized_interface.jl
@@ -1,9 +1,0 @@
-@testitem "Test interfaces are correctly implemented" default_imports = false begin
-    using InferOpt, RequiredInterfaces, Test
-    const RI = RequiredInterfaces
-
-    @test RI.check_interface_implemented(AbstractRegularized, RegularizedFrankWolfe)
-    @test RI.check_interface_implemented(AbstractRegularized, SoftArgmax)
-    @test RI.check_interface_implemented(AbstractRegularized, SparseArgmax)
-    @test RI.check_interface_implemented(AbstractRegularized, SoftRank)
-end

--- a/test/learning_generalized_maximizer.jl
+++ b/test/learning_generalized_maximizer.jl
@@ -230,8 +230,7 @@ end
 
 @testitem "Regularized with a GeneralizedMaximizer" default_imports = false begin
     include("InferOptTestUtils/src/InferOptTestUtils.jl")
-    using InferOpt, .InferOptTestUtils, Random, RequiredInterfaces, Test
-    const RI = RequiredInterfaces
+    using InferOpt, .InferOptTestUtils, Random, Test
     Random.seed!(63)
 
     struct MyRegularized{M<:LinearMaximizer} <: AbstractRegularized # GeneralizedMaximizer
@@ -243,8 +242,6 @@ end
         return InferOpt.sparse_argmax_regularization(y)
     end
     InferOpt.get_maximizer(regularized::MyRegularized) = regularized.maximizer
-
-    @test RI.check_interface_implemented(AbstractRegularized, MyRegularized)
 
     regularized = MyRegularized(LinearMaximizer(sparse_argmax))
 


### PR DESCRIPTION
JET tests are failing when run with Julia 1.12. Solution:
- Use a workspace for test environment
- Remove `RequiredInterfaces` dependency (outdated package, and not really needed)