### PR TITLE
build(dependencies): remove GridGraphs from test dependencies

### DIFF
--- a/test/InferOptTestUtils/Manifest.toml
+++ b/test/InferOptTestUtils/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "efd6b2186d3a52dbcc28fa3770defbc1277272f4"
+project_hash = "1ed34208728590c42c84d19a7ef4a0a9d84983a2"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "d9aaef7c63466eee4de23b4d9dad03629df54bea"

--- a/test/InferOptTestUtils/Project.toml
+++ b/test/InferOptTestUtils/Project.toml
@@ -1,12 +1,11 @@
 name = "InferOptTestUtils"
 uuid = "da316ebf-0808-4679-97b0-38aabd8f7bf9"
-authors = ["Guillaume Dalle", "Léo Baty", "Louis Bouvier", "Axel Parmentier"]
 version = "0.1.0"
+authors = ["Guillaume Dalle", "Léo Baty", "Louis Bouvier", "Axel Parmentier"]
 
 [deps]
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
 InferOpt = "4846b161-c94e-4150-8dac-c7ae193c601f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -14,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [sources]
-InferOpt = { path = "../.." }
+InferOpt = {path = "../.."}
 
 [compat]
 Flux = "0.16.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,7 +7,6 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-GridGraphs = "dd2b58c7-5af7-4f17-9e46-57c68ac813fb"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 InferOpt = "4846b161-c94e-4150-8dac-c7ae193c601f"
@@ -29,7 +28,6 @@ InferOpt = {path = ".."}
 
 [compat]
 Flux = "0.16.10"
-GridGraphs = "0.10"
 InferOpt = "0.7.2"
 JuliaFormatter = "2"
 Test = "1"


### PR DESCRIPTION
It is not needed anymore.